### PR TITLE
Daniel header footer

### DIFF
--- a/js/Worksheet.js
+++ b/js/Worksheet.js
@@ -17,7 +17,6 @@ const templateString = `
 :host {
     position: absolute;
     padding: 3px;
-    background-color: var(--palette-orange);
     display: flex;
     align-items: stretch;
     flex-direction: column;
@@ -25,6 +24,8 @@ const templateString = `
     z-index: 1;
     overflow: hidden; /* to make resize work */
     resize: both;
+    --bg-color: var(--palette-lightblue);
+    --sheet-bg-color: var(--palette-cyan);
 }
 
 #header-bar {
@@ -237,12 +238,6 @@ my-grid {
 
 `;
 
-// a few palette combo options for the sheet + bar area
-const paletteCombinations = [
-    {this: 'var(--palette-orange)', sheet: 'var(--palette-beige)'},
-    {this: 'var(--palette-lightblue)', sheet: 'var(--palette-cyan)'},
-    {this: 'var(--palette-cyan)', sheet: 'var(--palette-lightblue)'},
-]
 
 class Worksheet extends HTMLElement {
     constructor(){
@@ -262,7 +257,6 @@ class Worksheet extends HTMLElement {
         this.commandRegistry = commandRegistry;
 
         // generate a random palette for the worksheet
-        this.palette = paletteCombinations[Math.floor(Math.random() * paletteCombinations.length)];
 
         // name for the worksheet. Note: this is the name found in the header area
         // and also in the this.name attribute for querying and listening for changes
@@ -305,8 +299,8 @@ class Worksheet extends HTMLElement {
         this.setAttribute("targets", "");
 
         // set the palette
-        this.style.backgroundColor = this.palette.this;
-        this.shadowRoot.querySelector('my-grid').style.backgroundColor = this.palette.sheet;
+        this.style.backgroundColor = "var(--bg-color)";
+        this.shadowRoot.querySelector('my-grid').style.backgroundColor = "var(--sheet-bg-color)";
 
         const header = this.shadowRoot.querySelector('#header-bar');
         const name = header.querySelector('#title');

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1,0 +1,14 @@
+/* Various utility functions and helpers */
+
+/**
+ * I create a span element with svg element child from a svg string
+ */
+const createIconSVGFromString = function(iconString){
+    const parser = new DOMParser();
+    return parser.parseFromString(iconString, "image/svg+xml").documentElement; 
+}
+
+export {
+    createIconSVGFromString,
+    createIconSVGFromString as default
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "express": "^4.17.3"
-      }
+      },
+      "devDependencies": {}
     },
     "node_modules/accepts": {
       "version": "1.3.8",


### PR DESCRIPTION
### Main Points ###

This PR allows for a more programmatic addition of header/footer buttons to worksheet (really you can add any element you want). Worksheet now has [.addToFooter() and .addToHeader()](https://github.com/dkrasner/worksheet/compare/daniel-header-footer?expand=1#diff-d63b3e5baa408a9520b175842c16e48cf325e2556b82434ad808f0d17bf7a135R345) which can be called externally. This allows for others environments using worksheet to add their custom elements to header and footer. 

A few things to note:
* the worksheet title is still hardcoded and not added via .addToHeader() <- this can be changed if we want
* the footer allows three areas: left, middle and right, whereas the header only allows left and right (b/c of the hardcoded title in the middle)

I've reworked the default icon/button to be added via this method, which I think is cleaner. Additional css fixes for these and general cleanup. 

Note: I accidentally branched from #12 and then didn't want to deal with it. 