### PR TITLE
adding source and target selection in the callStack.onStep callback

### DIFF
--- a/js/callStack.js
+++ b/js/callStack.js
@@ -6,7 +6,11 @@
   * The call stack is built from an 'editor' sheet.
   */
 
-const EndOfStackError = new Error("End Of Stack");
+class EndOfStackError extends Error{
+    constructor() {
+        super();
+    }
+}
 
 class CallStack extends Object {
     constructor(interpreter){

--- a/js/interpreters.js
+++ b/js/interpreters.js
@@ -115,7 +115,11 @@ const commandRegistry = {
 /* I take a string like s="AA" and return its 'true'
    column index */
 const labelIndex = (s) => {
-    return letters.indexOf(s[0]) + (letters.length * (s.length - 1));
+    const index = letters.indexOf(s[0]) + (letters.length * (s.length - 1));
+    if(index){
+        return index;
+    }
+    return s;
 };
 
 const letters = [
@@ -128,5 +132,6 @@ const letters = [
 
 export {
     BasicInterpreter,
+    labelIndex,
     BasicInterpreter as default
 }


### PR DESCRIPTION
### Main Points ###

whenever the callStack moves the counter fwd (steps), it calls .onStep which is defined in the worksheet.
this method calls the ohm grammar and semantics functions on each respective
instruction, takes the source and target coordinates and toggles selections on each
in addition it highlights the instruction in the mapper worksheet as you step
down the stack

this is experimental and represents the sort of thing that would be nice to see. It will likely change after the linker element is integrated