### PR TITLE
Context Menu Styling Touchups and Refactor v1

### DIFF
--- a/css/context-menu.css
+++ b/css/context-menu.css
@@ -48,3 +48,9 @@ context-menu-item:hover {
     color: var(--ctx-item-font-color-highlighted);
     cursor: pointer;
 }
+
+context-menu hr {
+    height: 1px;
+    width: 100%;
+    background-color: black;
+}

--- a/css/context-menu.css
+++ b/css/context-menu.css
@@ -1,18 +1,33 @@
+* {
+    box-sizing: border-box;
+}
+
 context-menu {
     /* Variables */
     --ctx-item-font-color: var(--palette-black);
-    --ctx-item-font-color-highlighted: var(--palette-white);
+    --ctx-item-font-color-highlighted: var(--palette-black);
     --ctx-item-background-color: var(--palette-white);
-    --ctx-item-background-color-highlighted: var(--palette-black);
+    --ctx-item-background-color-highlighted: var(--palette-cyan);
+    --ctx-item-font-color-active: var(--palette-white);
+    --ctx-item-background-color-active: var(--palette-black);
+    --ctx-menu-border-color: rgba(0, 0, 0, 0.4);
+    --ctx-menu-border-radius: 5px;
+    --ctx-menu-box-shadow: 6px 6px 14px -5px rgba(0,0,0,0.38);
     display: block;
     position: absolute;
     max-width: 450px;
-    border: 1px solid var(--ctx-item-background-color-highlighted);
-    background-color: white;
+    border: 1px solid var(--ctx-menu-border-color);
+    background-color: var(--palette-white);
+    border-radius: var(--ctx-menu-border-radius);
+    box-shadow: var(--ctx-menu-box-shadow);
+}
+
+context-menu-item > context-menu {
+    
 }
 
 context-menu,
-context-menu * {
+context-menu-item {
     box-sizing: border-box;
 }
 
@@ -31,16 +46,24 @@ context-menu-item {
     width: 100%;
     align-items: center;
     justify-content: space-between;
-    padding-left: 4px;
+    padding-left: 8px;
     padding-right: 4px;
-    padding-top: 2px;
-    padding-bottom: 2px;
-    background-color: var(--ctx-item-background-color);
+    padding-top: 4px;
+    padding-bottom: 4px;
     color: var(--ctx-item-font-color);
+    background-color: var(--palette-white);
 }
 
-context-menu-item + context-menu-item {
-    
+context-menu-item:last-child {
+    border-bottom-left-radius: var(--ctx-menu-border-radius);
+    border-bottom-right-radius: var(--ctx-menu-border-radius);
+    padding-bottom: 8px;
+}
+
+context-menu-item:first-child {
+    border-top-left-radius: var(--ctx-menu-border-radius);
+    border-top-right-radius: var(--ctx-menu-border-radius);
+    padding-top: 8px;
 }
 
 context-menu-item:hover {
@@ -49,8 +72,16 @@ context-menu-item:hover {
     cursor: pointer;
 }
 
+context-menu-item:hover.item-active {
+    background-color: var(--ctx-item-background-color-active);
+    color: var(--ctx-item-font-color-active);
+}
+
 context-menu hr {
     height: 1px;
     width: 100%;
-    background-color: black;
+    background-color: var(--ctx-menu-border-color);
+    margin: 0;
+    padding: 0;
+    border: 0;
 }

--- a/examples/context-menu-styling.html
+++ b/examples/context-menu-styling.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Context Menu Styling</title>
+        <script src="../js/ContextMenu.js" type="module"></script>
+        <link rel="stylesheet" type="text/css" href="../css/core.css" />
+        <link rel="stylesheet" type="text/css" href="../css/context-menu.css" />
+    </head>
+    <body>
+       <section id="static-example">
+            <context-menu>
+                <context-menu-item>First Item</context-menu-item>
+                <context-menu-item>Second Item</context-menu-item>
+                <context-menu-item>Third Item</context-menu-item>
+                <hr></hr>
+                <context-menu-item>
+                    Fourth Item
+                    <context-menu slot="submenu" class="context-submenu submenu-hidden">
+                        <context-menu-item>First Submenu Item</context-menu-item>
+                        <context-menu-item>Second Submenu Item</context-menu-item>
+                        <context-menu-item>Third Submenu Item</context-menu-item>
+                    </context-menu>
+                </context-menu-item>
+                <hr></hr>
+                <context-menu-item>Fifth Item</context-menu-item>
+                <context-menu-item>Sixth Item</context-menu-item>
+            </context-menu>
+       </section>
+       <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // Remove the active mouse listeners from the context menu
+            // so that it stays on the screen
+            document.querySelector('context-menu').disconnectedCallback();
+        });
+       </script>
+    </body>
+</html>

--- a/examples/context-menu-styling.html
+++ b/examples/context-menu-styling.html
@@ -13,7 +13,7 @@
                 <context-menu-item>Second Item</context-menu-item>
                 <context-menu-item>Third Item</context-menu-item>
                 <hr></hr>
-                <context-menu-item>
+                <context-menu-item class="with-submenu">
                     Fourth Item
                     <context-menu slot="submenu" class="context-submenu submenu-hidden">
                         <context-menu-item>First Submenu Item</context-menu-item>
@@ -31,6 +31,7 @@
             // Remove the active mouse listeners from the context menu
             // so that it stays on the screen
             document.querySelector('context-menu').disconnectedCallback();
+            document.querySelector('.with-submenu').showCaret();
         });
        </script>
     </body>

--- a/examples/context-menu.html
+++ b/examples/context-menu.html
@@ -7,116 +7,120 @@
         <link rel="stylesheet" type="text/css" href="../css/context-menu.css" />
     </head>
     <body>
-        <h3>Right-click anywhere on the screen to reveal the context menu.</h3>
-        <div id="outer1" class="example-container">
-            <div id="inner1" class="example-container">
-                <div id="inner2" class="example-container"></div>
-                <div id="inner3" class="example-container"></div>
+        <section id="dynamic-example">
+            <h3>
+                Right-click anywhere on the screen to reveal the context menu.
+            </h3>
+            <div id="outer1" class="example-container">
+                <div id="inner1" class="example-container">
+                    <div id="inner2" class="example-container"></div>
+                    <div id="inner3" class="example-container"></div>
+                </div>
             </div>
-        </div>
-        <style>
-            @keyframes myAnimation {
-                0% {
-                    transform: scale(1);
+            <style>
+                @keyframes myAnimation {
+                    0% {
+                        transform: scale(1);
+                    }
+                    50% {
+                        transform: scale(3);
+                    }
+                    100% {
+                        transofmr: scale(1);
+                    }
                 }
-                50% {
-                    transform: scale(3);
+                #outer1 {
+                    display: block;
+                    transform: translateX(20vw);
+                    width: 100px;
+                    height: 120px;
+                    background-color: green;
+                    padding: 10px;
                 }
-                100% {
-                    transofmr: scale(1);
+                #inner1 {
+                    display: block;
+                    width: 80px;
+                    height: 80px;
+                    background-color: orange;
                 }
-            }
-            #outer1 {
-                display: block;
-                transform: translateX(20vw);
-                width: 100px;
-                height: 120px;
-                background-color: green;
-                padding: 10px;
-            }
-            #inner1 {
-                display: block;
-                width: 80px;
-                height: 80px;
-                background-color: orange;
-            }
-            #inner2,
-            #inner3 {
-                display: block;
-                width: 30px;
-                height: 30px;
-                background-color: blue;
-            }
-            #inner3 {
-                background-color: red;
-            }
-            .animate {
-                animation: myAnimation 0.2s ease-in;
-            }
-        </style>
-        <script>
-            document.addEventListener("DOMContentLoaded", () => {
-                const examples = Array.from(
-                    document.querySelectorAll(".example-container")
-                );
-                examples.forEach((element) => {
-                    element.addEventListener("contextmenu", (event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        const menu = document.createElement("context-menu");
-                        examples
-                            .map((containerEl) => {
-                                return containerEl.id;
-                            })
-                            .filter((id) => {
-                                return id && id !== "" && id !== element.id;
-                            })
-                            .forEach((id) => {
-                                menu.addListItem(id, (e) => {
-                                    const el = document.getElementById(id);
-                                    examples.forEach((element) =>
-                                        element.classList.remove("animate")
-                                    );
-                                    el.classList.remove("animate");
-                                    el.classList.add("animate");
+                #inner2,
+                #inner3 {
+                    display: block;
+                    width: 30px;
+                    height: 30px;
+                    background-color: blue;
+                }
+                #inner3 {
+                    background-color: red;
+                }
+                .animate {
+                    animation: myAnimation 0.2s ease-in;
+                }
+            </style>
+            <script>
+                document.addEventListener("DOMContentLoaded", () => {
+                    const examples = Array.from(
+                        document.querySelectorAll(".example-container")
+                    );
+                    examples.forEach((element) => {
+                        element.addEventListener("contextmenu", (event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            const menu = document.createElement("context-menu");
+                            examples
+                                .map((containerEl) => {
+                                    return containerEl.id;
+                                })
+                                .filter((id) => {
+                                    return id && id !== "" && id !== element.id;
+                                })
+                                .forEach((id) => {
+                                    menu.addListItem(id, (e) => {
+                                        const el = document.getElementById(id);
+                                        examples.forEach((element) =>
+                                            element.classList.remove("animate")
+                                        );
+                                        el.classList.remove("animate");
+                                        el.classList.add("animate");
+                                    });
                                 });
-                            });
-                        menu.openAtMouseEvent(event);
+                            menu.openAtMouseEvent(event);
+                        });
                     });
                 });
-            });
-            document.addEventListener("contextmenu", (event) => {
-                event.preventDefault();
-                const menu = document.createElement("context-menu");
+                document.addEventListener("contextmenu", (event) => {
+                    event.preventDefault();
+                    const menu = document.createElement("context-menu");
 
-                menu.addListItem("First Item", (e) => {
-                    alert("First Item!");
-                })
-                    .addListItem("Second Item", (e) => {
-                        alert("Second Item!");
+                    menu.addListItem("First Item", (e) => {
+                        alert("First Item!");
                     })
-                    .addListItemWithSubmenu(
-                        "Third Item",
-                        (e) => {
-                            alert("Third Item -- submenu");
-                        },
-                        (submenu) => {
-                            submenu
-                                .addListItem("First Item", (e) => {
-                                    alert("First Submenu Item!");
-                                })
-                                .addListItem("Second Item", (e) => {
-                                    alert("Second Submenu Item!");
-                                });
-                        }
-                    )
-                    .addListItem("Fourth Item", (e) => {
-                        alert("Fourth Item!");
-                    });
-                menu.style.top = `${event.pageY}px`;
-                menu.style.left = `${event.pageX}px`;
-                document.body.append(menu);
-            });
-        </script>
+                        .addListItem("Second Item", (e) => {
+                            alert("Second Item!");
+                        })
+                        .addListItemWithSubmenu(
+                            "Third Item",
+                            (e) => {
+                                alert("Third Item -- submenu");
+                            },
+                            (submenu) => {
+                                submenu
+                                    .addListItem("First Item", (e) => {
+                                        alert("First Submenu Item!");
+                                    })
+                                    .addListItem("Second Item", (e) => {
+                                        alert("Second Submenu Item!");
+                                    });
+                            }
+                        )
+                        .addListItem("Fourth Item", (e) => {
+                            alert("Fourth Item!");
+                        });
+                    menu.style.top = `${event.pageY}px`;
+                    menu.style.left = `${event.pageX}px`;
+                    document.body.append(menu);
+                });
+            </script>
+        </section>
     </body>
 </html>

--- a/js/ContextMenu.js
+++ b/js/ContextMenu.js
@@ -4,11 +4,11 @@ const CONTEXT_ITEM_EL_NAME = "context-menu-item";
 const templateString = `
 <style>
     :host {
+        box-sizing: border-box;
         display: flex;
         flex-direction: column;
         position: absolute;
         z-index: 10000;
-        padding-bottom: 8px;
         min-width: 200px;
     }
 
@@ -76,11 +76,11 @@ class ContextMenu extends HTMLElement {
         }
 
         // Remove any existing context menus in the document
-        Array.from(document.querySelectorAll(CONTEXT_MENU_EL_NAME))
-            .filter((element) => {
-                return element !== this;
-            })
-            .forEach((element) => element.remove());
+        // Array.from(document.querySelectorAll(CONTEXT_MENU_EL_NAME))
+        //     .filter((element) => {
+        //         return element !== this;
+        //     })
+        //     .forEach((element) => element.remove());
     }
 
     disconnectedCallback() {
@@ -119,11 +119,13 @@ class ContextMenu extends HTMLElement {
     }
 
     handleOutsideClick() {
-        this.remove();
+        if (!this.isSubmenu) {
+            this.remove();
+        }
     }
 
     handleEscapeKey(event) {
-        if (event.key == "Escape") {
+        if (event.key == "Escape" && !this.isSubmenu) {
             this.remove();
         }
     }
@@ -133,14 +135,20 @@ class ContextMenu extends HTMLElement {
         this.style.left = `${event.pageX}px`;
         document.body.append(this);
     }
+
+    get isSubmenu() {
+        return this.hasAttribute("slot");
+    }
 }
 
 const itemTemplateString = `
 <style>
     :host {
+        box-sizing: border-box;
         display: flex;
         position: relative;
     }
+
     .submenu-area {
         display: none;
         position: absolute;
@@ -158,6 +166,12 @@ const itemTemplateString = `
         width: 100%;
     }
 
+    .label-area,
+    .label,
+    .caret {
+        user-select: none;
+    }
+
     .caret.hidden {
         display: none;
     }
@@ -165,6 +179,7 @@ const itemTemplateString = `
         display: block;
         margin-left: auto;
     }
+}
 </style>
 <div class="label-area">
     <span class="label"><slot></slot></span>
@@ -187,11 +202,41 @@ class ContextMenuItem extends HTMLElement {
 
         // Bound methods
         this.showCaret = this.showCaret.bind(this);
+        this.onMouseDown = this.onMouseDown.bind(this);
+        this.highlightActive = this.highlightActive.bind(this);
+        this.unHighlightActive = this.unHighlightActive.bind(this);
     }
 
     showCaret() {
         const caretEl = this.shadowRoot.querySelector(".caret");
         caretEl.classList.remove("hidden");
+    }
+
+    connectedCallback() {
+        if (this.isConnected) {
+            this.addEventListener("mousedown", this.onMouseDown);
+        }
+    }
+
+    disconnectedCallback() {
+        this.removeEventListener("mousedown", this.onMouseDown);
+    }
+
+    onMouseDown(event) {
+        event.stopPropagation();
+        this.highlightActive();
+        this.addEventListener("mouseleave", this.unHighlightActive);
+        this.addEventListener("mouseup", this.unHighlightActive);
+    }
+
+    highlightActive() {
+        this.classList.add("item-active");
+    }
+
+    unHighlightActive() {
+        this.removeEventListener("mouseleave", this.unHighlightActive);
+        this.removeEventListener("mouseup", this.unHighlightActive);
+        this.classList.remove("item-active");
     }
 }
 


### PR DESCRIPTION
## What ##
This PR represents both a refactor of key parts of the ContextMenu custom element, and the styling that it uses when displaying, selecting, and activating items and submenus.
  
## Implementation ##
Important notes:
1. Use of CSS variables for most key styling properties, almost all of them based on the core palette.
2. Use of customized internal mouse events to set an "active" state (`.item-active`) as opposed to relying on the `:active` pseudo for styling when the mouse is down on a menu item. The problem with the plain pseudo element is that in nested submenus the parent item _and_ a list item in the child submenu would both be styled as active.
3. All around styling improvements
  
## Trying it out ##
You can still use the old test file, but there is also a more static representation of a menu [here](https://github.com/dkrasner/worksheet/blob/eric-context-touchups-1/examples/context-menu-styling.html) (which stays on the screen) designed to test styling.