### PR TITLE
Excel file support + 

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -23,3 +23,31 @@ svg#sheet:hover{
     width: 50px;
     height:50px;
 }
+
+dialog {
+    min-width: 150px;
+    background: var(--palette-cyan);
+    border: solid 1px;
+    border-radius: 5px;
+}
+
+dialog div {
+    display: flex;
+    justify-content: space-around;
+}
+
+dialog button {
+    background: var(--palette-white);
+}
+
+dialog #remove {
+    position: absolute;
+    top: 1px;
+    right: 1px;
+    cursor: pointer;
+}
+
+dialog #remove > svg {
+    width: 18px;
+    height: 18px;
+}

--- a/css/core.css
+++ b/css/core.css
@@ -34,6 +34,7 @@ dialog {
 dialog div {
     display: flex;
     justify-content: space-around;
+    margin-top: 5px;
 }
 
 dialog button {

--- a/js/Worksheet.js
+++ b/js/Worksheet.js
@@ -658,7 +658,7 @@ class Worksheet extends HTMLElement {
             const rABS = !!reader.readAsBinaryString;
             reader.addEventListener("load", (loadEv) => {
                 if(ftype == 'csv'){
-                    this.fromCSV(loadEv.target.result, filename);
+                    this.fromCSV(loadEv.target.result, fileName);
                 } else {
                     this.fromExcel(
                         loadEv.target.result,
@@ -1119,8 +1119,16 @@ class Worksheet extends HTMLElement {
         const data = CSVParser.parse(aString).data;
         if (data) {
             this.sheet.dataFrame.clear();
-            this.sheet.dataFrame.corner.x = data[0].length - 1;
-            this.sheet.dataFrame.corner.y = data.length - 1;
+            this.sheet.dataFrame.corner.x = Math.max(
+                Math.max(
+                    ...data.map((row) => {return row.length})
+                ) - 1,
+                this.sheet.dataFrame.corner.x
+            );
+            this.sheet.dataFrame.corner.y = Math.max(
+                data.length - 1,
+                this.sheet.dataFrame.corner.y
+            );
             this.sheet.dataFrame.loadFromArray(data);
             this.sheet.render();
             // set the name of the sheet to the file name; TODO: do we want this?
@@ -1157,6 +1165,16 @@ class Worksheet extends HTMLElement {
                     {header: 1} // this will give us an nd-array
                 );
                 this.onErase();
+                this.sheet.dataFrame.corner.x = Math.max(
+                    Math.max(
+                        ...wsArray.map((row) => {return row.length})
+                    ) - 1,
+                    this.sheet.dataFrame.corner.x
+                );
+                this.sheet.dataFrame.corner.y = Math.max(
+                    wsArray.length - 1,
+                    this.sheet.dataFrame.corner.y
+                );
                 this.sheet.dataFrame.loadFromArray(wsArray);
                 // update the file name to include the sheet/tab
                 fileName = fileName.replace(`.${ftype}`, `[${event.target.value}]`);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "resize-observer-polyfill": "^1.5.1",
     "skeleton-loader": "^2.0.0",
     "webpack": "^5.73.0",
-    "webpack-cli": "^4.10.0"
+    "webpack-cli": "^4.10.0",
+    "xlsx": "^0.18.5"
   },
   "directories": {
     "example": "examples"


### PR DESCRIPTION
### Main Points ###

This PR adds excel (xlsx, xls) file support for both upload and download. It is based on the [sheet-js](https://docs.sheetjs.com/docs/getting-started/) library, which seems to be pretty active. In the process, I've added a [dialog](https://github.com/dkrasner/worksheet/compare/daniel-xlsx?expand=1#diff-d63b3e5baa408a9520b175842c16e48cf325e2556b82434ad808f0d17bf7a135R1203) element which is the interface to 

1. choosing which type of file to download (excel or csv). Arguably I could have done with 2 separate download icons but I couldn't find corresponding csv/excel ones in tabler and the dialog gives you the option to download both at the same time..
![Screen Shot 2022-09-21 at 12 37 07 PM](https://user-images.githubusercontent.com/1154326/191484225-fe56a710-922f-419c-aae3-87ba06edb3f7.png)
2. choosing which sheet you want to upload, since we don't support multiple sheets/tabs (although i could see how to do this in worksheet down the line...). Again the dialog allows you to choose different sheets before committing. 

![Screen Shot 2022-09-21 at 12 36 51 PM](https://user-images.githubusercontent.com/1154326/191485079-eb2d314f-afdc-4a00-a184-574b5b8cd67f.png)

Sheet names are preserved in both the worksheet and on download. 

A few things to note:
1. the sheet-js library does support csv's, although this is relatively new, but there were some minor issues and I decided to leave things as is. There is also a chance we'll have to drop it for another library because of...
2. dates dates.... uggh so excel natively supports dates as we know, but when you transfer from one software to another there is no guarantee that the same string representation will appear. The default for sheet-js is to display a numerical representation (although this doesn't seem to be seconds from epoch...), so when someone has "1/1/2022" they see some number on import - this is confusing. There are various [options](https://docs.sheetjs.com/docs/api/parse-options/) and after a while playing around I left it with [this](https://github.com/dkrasner/worksheet/compare/daniel-xlsx?expand=1#diff-d63b3e5baa408a9520b175842c16e48cf325e2556b82434ad808f0d17bf7a135R1147). Unfortunately this converts to a sheet-js default string representation. I think there might be a way to get around this by digging into the sheet-js worksheet data object and seeing if the original string rep is carried along, but I decided to kick the can down the road here. 
