### PR TITLE
Adding emacs .dir-locals for consistent formatting options

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+((prettier-js-mode . ((prettier-js-args . '("--tab-width" 4))))
+ (js2-mode
+  (js2-basic-offset . 4))
+ (typescriptreact-mode
+  (typescript-indent-level . 4)))


### PR DESCRIPTION
## What ##
Small pr that adds a `.dir-locals.el` file for Emacs users so that formatting options are consistent for the relevant modes.