### PR TITLE
rewriting replace arg input

### DIFF
--- a/js/CommandInterface.js
+++ b/js/CommandInterface.js
@@ -325,12 +325,17 @@ class CommandInterface extends HTMLElement {
         // TODO: this is a bit absurd! we are joining the source and target data
         // into a string only to parse it all out later. I am leaving this in for now
         // so that our 'view' on the callstack __is__ the callstack
+        const argsDict = {};
+        args.split("\n").forEach((entry) => {
+            const [k, v] = entry.split(/\s*=>\s*/);
+            argsDict[k] = v;
+        })
         const sources = this.sources.map((s) => {
             return `${s.id}!(${s.origin[0]},${s.origin[1]}):(${s.corner[0]},${s.corner[1]})`;
         }).join(",");
         const target = `${this.target.id}!(${this.target.origin[0]},${this.target.origin[1]}):(${this.target.corner[0]},${this.target.corner[1]})`;
         // TODO: do we really need command(args) or can we seperate them out command, args for ex 
-        command = `${command}(${args})`;
+        command = `${command}(${JSON.stringify(argsDict)})`;
         return [sources, target, command];
     }
 

--- a/js/interpreters.js
+++ b/js/interpreters.js
@@ -125,9 +125,13 @@ const commandRegistry = {
     "replace": {
         command: replace,
         description: 'Replace content with new\n' +
-            'Use a dictionary where the keys and values specify\n' +
+            'Use the "=>" arrow symbol to specify\n' +
             'what and with-what to replace, respectively.\n' +
-            '(Example: {"1": "ONE", "2": "TWO"} will replace 1 with ONE and 2 with TWO)\n'
+            'Each new line will represent a new replacement pair.\n' +
+            '(Example:\n' +
+            '1 => ONE\n' +
+            '2 => TWO\n' +
+            'will replace "1" with "ONE" and "2" with "TWO".)'
         ,
         args: true
     },


### PR DESCRIPTION
### Main Points ###

The current implementation of replace uses a dict (string) to indicate the replace arguments. This is unnecessary and awkward. This small PR rewrites the grammar to accept a k:v input one per line. 