### PR TITLE
rewriting replace arg grammar and semantics

### DIFF
--- a/js/interpreters.js
+++ b/js/interpreters.js
@@ -103,9 +103,9 @@ const replace = (sources, target, d) => {
     if(d){
         sourceDF.apply((entry) => {
             if(entry){
-                for(const key in d){
-                    entry = entry.replaceAll(key, d[key]);
-                }
+                d.forEach((item) => {
+                    entry = entry.replaceAll(item[0], item[1]);
+                })
             }
             return entry;
         })
@@ -125,9 +125,12 @@ const commandRegistry = {
     "replace": {
         command: replace,
         description: 'Replace content with new\n' +
-            'Use a dictionary where the keys and values specify\n' +
+            'Use a ":" where the keys and values specify\n' +
             'what and with-what to replace, respectively.\n' +
-            '(Example: {"1": "ONE", "2": "TWO"} will replace 1 with ONE and 2 with TWO)\n'
+            '(Example:\n' +
+            '"1": "ONE"\n' +
+            '"2": "TWO"\n' +
+            'will replace 1 with ONE and 2 with TWO)\n'
         ,
         args: true
     },

--- a/tests/commandGrammarSemantics.js
+++ b/tests/commandGrammarSemantics.js
@@ -26,7 +26,7 @@ describe('Reference Grammar and Semantics', function () {
             semanticMatchFailTest("copy", "Copy");
         });
         it('Replace', function () {
-            const s = "replace({'a': 1, 'b': 2})";
+            const s = "replace('a': 1\n 'b': 2)";
             matchTest(s);
             semanticMatchTest(s, "Replace");
         });
@@ -43,23 +43,13 @@ describe('Reference Grammar and Semantics', function () {
             const s = "join()";
             semanticMatchFailTest(s, "Join");
         });
-        it('Dict (single quotes)', function () {
-            const s = "{'a': '1', 'b': '2'}";
-            semanticMatchTest(s, "Dict");
+        it('Replace Arg', function () {
+            const s = "'a':1\n'b':2\n";
+            semanticMatchTest(s, "ReplaceArg");
         });
-        it('Dict (double quotes)', function () {
-            const s = '{"a": "a", "b": "b"}';
-            semanticMatchTest(s, "Dict");
-        });
-        it('Dict (empty key or value)', function () {
-            let s = "{'': '1', 'b': 2}";
-            semanticMatchTest(s, "Dict");
-            s = "{'a': '', 'b': 2}";
-            semanticMatchTest(s, "Dict");
-        });
-        it('Dict (some values digits)', function () {
-            const s = "{'a': '1', 'b': 2}";
-            semanticMatchTest(s, "Dict");
+        it('Replace Arg (spaces)', function () {
+            const s = "'a':1\n' b':2\n";
+            semanticMatchTest(s, "ReplaceArg");
         });
         it('String literal return proper literal', function () {
             const s = "'this is a literal'";
@@ -74,10 +64,16 @@ describe('Reference Grammar and Semantics', function () {
             expect(result).to.eql(["copy", ""]);
         });
         it('Replace', function () {
-            const s= "replace({'a': 1, 'b': 2})";
+            const s= "replace('a': 'AAAA'\n'b': 'BBBB')";
             const m = g.match(s);
             const result = semantics(m).interpret();
-            expect(result).to.eql(["replace", {'a': 1, 'b': 2}]);
+            expect(result).to.eql(["replace", [["a", "AAAA"], ["b", "BBBB"]]]);
+        });
+        it('Replace (digits)', function () {
+            const s= "replace('a': 1\n'b': 2)";
+            const m = g.match(s);
+            const result = semantics(m).interpret();
+            expect(result).to.eql(["replace", [["a", "1"], ["b", "2"]]]);
         });
         it('Join', function () {
             const s= "join(',')";

--- a/tests/interpreter-tests.js
+++ b/tests/interpreter-tests.js
@@ -82,7 +82,7 @@ describe("Interpreter Tests", () => {
         });
         it("Running the replace command populates target Worksheet", () => {
             const instructions = [
-                [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(0,0):(0,0)`, "replace({'a': 'AAA'})"],
+                [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(0,0):(0,0)`, "replace('a': 'AAA')"],
             ]
             callstack.load(instructions);
             callstack.run();
@@ -101,7 +101,7 @@ describe("Interpreter Tests", () => {
         it("Running copy and replace commands populates target Worksheet", () => {
             const instructions = [
                 [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(0,0):(0,0)`, "copy()"],
-                [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(3,0):(3,0)`, "replace({'a': 'AAA'})"],
+                [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(3,0):(3,0)`, "replace('a': 'AAA')"],
             ]
             callstack.load(instructions);
             callstack.run();
@@ -126,7 +126,7 @@ describe("Interpreter Tests", () => {
         it("Stepping through copy and replace commands populates target Worksheet", () => {
             const instructions = [
                 [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(0,0):(0,0)`, "copy()"],
-                [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(3,0):(3,0)`, "replace({'a': 'AAA'})"],
+                [`${sourceWS.id}!(0,0):(2,2)`, `${targetWS.id}!(3,0):(3,0)`, "replace('a': 'AAA')"],
             ]
             callstack.load(instructions);
             callstack.step();


### PR DESCRIPTION
The current implementation of replace uses a dict (string) to indicate the replace arguments. This is unnecessary and awkward. This small PR rewrites the grammar to accept a k:v input one per line.

+ tests