### PR TITLE
CSV file chunking

### DIFF
--- a/js/Worksheet.js
+++ b/js/Worksheet.js
@@ -1018,17 +1018,26 @@ class Worksheet extends HTMLElement {
         let rowsProcessed = 0;
         // we are not binding the parse callbacks here
         const self = this;
+        let icon = icons.loader;
         const parseConfig = {
             worker: true, // run the upload on a Worker not to block things up
             chunk: function(chunk){
+                self._overlay(icon);
                 self.sheet.dataFrame.loadFromArray(chunk.data, [0, rowsProcessed], false);
                 rowsProcessed += chunk.data.length;
+                if(icon == icons.loader){
+                    icon = icons.loaderQuarter;
+                } else {
+                    icon = icons.loader;
+                }
                 console.log("processed:", rowsProcessed);
             },
             complete: function(){
                 self.sheet.render();
                 console.log("total rows:", rowsProcessed);
                 self.updateName(file.name);
+                const overlay = self.shadowRoot.querySelector(".overlay");
+                overlay.classList.add("hide");
             }
         }
         try {

--- a/js/Worksheet.js
+++ b/js/Worksheet.js
@@ -1072,27 +1072,20 @@ class Worksheet extends HTMLElement {
         this.openExcelUploadDialog(wb, (event) => {
             const ws = wb.Sheets[event.target.value];
             if(ws){
+                this._overlay(icons.loader);
                 const wsArray = XLSX.utils.sheet_to_json(
                     ws,
                     {header: 1} // this will give us an nd-array
                 );
                 this.onErase();
-                this.sheet.dataFrame.corner.x = Math.max(
-                    Math.max(
-                        ...wsArray.map((row) => {return row.length})
-                    ) - 1,
-                    this.sheet.dataFrame.corner.x
-                );
-                this.sheet.dataFrame.corner.y = Math.max(
-                    wsArray.length - 1,
-                    this.sheet.dataFrame.corner.y
-                );
                 this.sheet.dataFrame.loadFromArray(wsArray);
                 // update the file name to include the sheet/tab
                 fileName = fileName.replace(`.${ftype}`, `[${event.target.value}]`);
                 fileName = fileName.replace(/\[.+\]$/, `[${event.target.value}]`);
                 // set the name of the sheet to the file name; TODO: do we want this?
                 this.updateName(fileName);
+                const overlay = this.shadowRoot.querySelector(".overlay");
+                overlay.classList.add("hide");
             }
         });
     }

--- a/js/Worksheet.js
+++ b/js/Worksheet.js
@@ -12,6 +12,7 @@ import icons from "./utils/icons.js";
 import createIconSVGFromString from "./utils/helpers.js";
 import * as XLSX from 'xlsx';
 import CSVParser from "papaparse";
+import Papa from 'papaparse';
 import ContextMenuHandler from "./ContextMenuHandler.js";
 
 // Simple grid-based sheet component
@@ -646,33 +647,27 @@ class Worksheet extends HTMLElement {
         const formats = ['csv', 'xlsx', 'xls'];
         const rexp = new RegExp(`(?:${formats.join('|')})$`);
         const file = event.target.files[0];
-        let fileName = file.name;
+        const fileName = file.name;
         if(rexp.test(fileName)){
             const ftype = rexp.exec(fileName)[0];
-            const reader = new FileReader();
-            const rABS = !!reader.readAsBinaryString;
-            reader.addEventListener("load", (loadEv) => {
-                if(ftype == 'csv'){
-                    this.fromCSV(loadEv.target.result, fileName);
-                } else {
+            if(ftype == 'csv'){
+                this.fromCSV(file);
+            } else {
+                const reader = new FileReader();
+                const rABS = !!reader.readAsBinaryString;
+                reader.addEventListener("load", (loadEv) => {
                     this.fromExcel(
                         loadEv.target.result,
                         rABS,
                         fileName,
                         ftype
                     );
-                }
-            });
-            reader.addEventListener("error", (e) => {
-                console.error(e);
-                alert("An error occurred reading this file");
-                return;
-            });
-            if(ftype == 'csv'){
-                // Will trigger the reader.load event
-                reader.readAsText(file);
-            } else {
-                // excel files
+                });
+                reader.addEventListener("error", (e) => {
+                    console.error(e);
+                    alert("An error occurred reading the xlsx file; try converting to csv first!");
+                    return;
+                });
                 if(rABS){
                     reader.readAsBinaryString(file)
                 } else {
@@ -1012,24 +1007,35 @@ class Worksheet extends HTMLElement {
         return iconSpan;
     }
 
-    fromCSV(aString, fileName) {
-        const data = CSVParser.parse(aString).data;
-        if (data) {
-            this.sheet.dataFrame.clear();
-            this.sheet.dataFrame.corner.x = Math.max(
-                Math.max(
-                    ...data.map((row) => {return row.length})
-                ) - 1,
-                this.sheet.dataFrame.corner.x
-            );
-            this.sheet.dataFrame.corner.y = Math.max(
-                data.length - 1,
-                this.sheet.dataFrame.corner.y
-            );
-            this.sheet.dataFrame.loadFromArray(data);
-            this.sheet.render();
-            // set the name of the sheet to the file name; TODO: do we want this?
-            this.updateName(fileName);
+    /**
+      * I hadle csv files. This is done by iterating over
+      * chunks (default size 10MB) and updating the sheet.DataFrame
+      * accordigly. This is a bit slower, on small files, than loading in one go
+      * but it allows for dealing with all files uniformly (the different for small
+      * files is unnoticeable).
+      **/
+    fromCSV(file) {
+        let rowsProcessed = 0;
+        // we are not binding the parse callbacks here
+        const self = this;
+        const parseConfig = {
+            worker: true, // run the upload on a Worker not to block things up
+            chunk: function(chunk){
+                self.sheet.dataFrame.loadFromArray(chunk.data, [0, rowsProcessed], false);
+                rowsProcessed += chunk.data.length;
+                console.log("processed:", rowsProcessed);
+            },
+            complete: function(){
+                self.sheet.render();
+                console.log("total rows:", rowsProcessed);
+                self.updateName(file.name);
+            }
+        }
+        try {
+            Papa.parse(file, parseConfig);
+        } catch (e){
+            console.log(e);
+            alert("I couldn't process the csv; please try again");
         }
     }
 

--- a/js/utils/icons.js
+++ b/js/utils/icons.js
@@ -177,6 +177,25 @@ const minimize = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-table
   <line x1="15" y1="15" x2="21" y2="21" />
 </svg>`;
 
+const loader = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-loader" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <line x1="12" y1="6" x2="12" y2="3" />
+  <line x1="16.25" y1="7.75" x2="18.4" y2="5.6" />
+  <line x1="18" y1="12" x2="21" y2="12" />
+  <line x1="16.25" y1="16.25" x2="18.4" y2="18.4" />
+  <line x1="12" y1="18" x2="12" y2="21" />
+  <line x1="7.75" y1="16.25" x2="5.6" y2="18.4" />
+  <line x1="6" y1="12" x2="3" y2="12" />
+  <line x1="7.75" y1="7.75" x2="5.6" y2="5.6" />
+</svg>`;
+
+const loaderQuarter = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-loader-quarter" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <line x1="12" y1="6" x2="12" y2="3" />
+  <line x1="6" y1="12" x2="3" y2="12" />
+  <line x1="7.75" y1="7.75" x2="5.6" y2="5.6" />
+</svg>`;
+
 const icons = {
     affiliate: affiliate,
     ban: ban,
@@ -197,6 +216,8 @@ const icons = {
     unlink: unlink,
     fileUpload: fileUpload,
     fileDownload: fileDownload,
+    loader: loader,
+    loaderQuarter: loaderQuarter,
     maximize: maximize,
     minimize: minimize,
 };


### PR DESCRIPTION
### Main Points ###

This PR addresses some of issue #50 . We now use paparse chunking/streaming to upload csv. This does not prevent any sort of memory overload when we store all data in the sheet.dataFrame, but it doesn't lock up the page and doesn't force the entire csv to be read in as a string into memory and then parsed. 

So an improvement of sorts. In the future, I think we'll use the same chunking/streaming to write to a different data store. 

